### PR TITLE
Add can board mcu temp sensor

### DIFF
--- a/Klipper CFG/EBB.cfg
+++ b/Klipper CFG/EBB.cfg
@@ -17,6 +17,12 @@
 #serial: /dev/serial/by-id/usb-Klipper_Klipper_firmware_12345-if00
 canbus_uuid: ebf7f23a7d85 # A remplacer par votre UUID
 
+[temperature_sensor can_temp]
+sensor_type: temperature_mcu
+sensor_mcu: EBBCan
+min_temp: 0
+max_temp: 100
+
 #[adxl345]
 #cs_pin: EBBCan: PB12
 #spi_software_sclk_pin: EBBCan: PB10


### PR DESCRIPTION
This PR adds a simple configuration that allows to get mcu temperature in Mainsail/Fluidd dashboard.